### PR TITLE
Update README title to match package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eml-js
+# eml-parse-js
 [RFC 822](https://www.w3.org/Protocols/rfc822/) EML file format parser and builder, Can be used in browser environment
 
 > fork from `eml-format-js`(used in Browser env) & `eml-format` (used in NodeJs env)


### PR DESCRIPTION
I made the mistake of trying to install `eml-js` rather than `eml-parse-js`, this should prevent that happening to others.