### PR TITLE
Fix RFC 2047 spaces encoded as underscores

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,6 +49,8 @@ export function mimeDecode(str = '', fromCharset = 'UTF-8') {
 		if (chr === '=' && hex && /[\da-fA-F]{2}/.test(hex)) {
 			buffer[bufferPos++] = parseInt(hex, 16);
 			i += 2;
+		} else if (chr === '_') {
+			buffer[bufferPos++] = 20; // space character
 		} else {
 			buffer[bufferPos++] = chr.charCodeAt(0);
 		}


### PR DESCRIPTION
Fixes MQpeng/eml-parse-js#3:

> Hi, I have an email containing the subject line `=?UTF-8?q?Off-The-Beaten-Path_Trails_You've_Never_Heard_Of!__=F0=9F=8C=8F?=`. This is decoded by my email client (Mail.app on macOS), as well as by the npm library [rfc2047](https://www.npmjs.com/package/rfc2047) as
> > Off-The-Beaten-Path Trails You've Never Heard Of! 🌏
> 
> However, this library instead returns 
> > Off-The-Beaten-Path_Trails_You've_Never_Heard_Of!__🌏
> 
> i.e. underscores are not successfully decoded into spaces. The relevant section of the standard is [RFC-2047, section 4.2.2](https://www.rfc-editor.org/rfc/rfc2047#section-4.2):
> 
> > 4. Encodings
> > 4.2. The "Q" encoding
> > (2) The 8-bit hexadecimal value 20 (e.g., ISO-8859-1 SPACE) may be represented as "\_" (underscore, ASCII 95.).  (This character may not pass through some internetwork mail gateways, but its use will greatly enhance readability of "Q" encoded data with mail readers that do not support this encoding.)  Note that the "\_" always represents hexadecimal 20, even if the SPACE character occupies a different code position in the character set in use.
> 
> ## Fix
> 
> I believe a fix would involve updating `mimeDecode` as follows:
> 
> ```diff
>          if (chr === '=' && hex && /[\da-fA-F]{2}/.test(hex)) {
>              buffer[bufferPos++] = parseInt(hex, 16);
>              i += 2;
>          }
> +        else if (chr === '_') {
> +            buffer[bufferPos++] = 20; // space character
> +        }
>          else {
>              buffer[bufferPos++] = chr.charCodeAt(0);
>          }
> ```