### PR TITLE
fix: use correct path for packge.json exports.".".types

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./types/index.d.ts",
+			"types": "./dist/index.d.ts",
 			"node": "./lib/bundle.cjs.js",
 			"require": "./lib/bundle.cjs.js",
 			"es2015": "./lib/bundle.esm.js",


### PR DESCRIPTION
When using new    `"moduleResolution": "Bundler"` option I got and error:

```
Could not find a declaration file for module 'eml-parse-js'. '/node_modules/eml-parse-js/lib/bundle.esm.js' implicitly has an 'any' type.
  There are types at 'node_modules/eml-parse-js/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'eml-parse-js' library may need to update its package.json or typings.ts(7016)
```

This is caused by exports section in packge.json:
```
"exports": {
		".": {
			"types": "./types/index.d.ts",
			"node": "./lib/bundle.cjs.js",
			"require": "./lib/bundle.cjs.js",
			"es2015": "./lib/bundle.esm.js",
			"default": "./lib/bundle.esm.js"
		}
	},
```
where `"types": "./types/index.d.ts",` is pointing to non existing path in published bundle.  Changing it to `"types": "./dist/index.d.ts"` fixes the issue.